### PR TITLE
Dispatcher validation configuration

### DIFF
--- a/example/config/dispatcher/dispatcher.ex
+++ b/example/config/dispatcher/dispatcher.ex
@@ -5,6 +5,7 @@ defmodule Dispatcher do
     html: ["text/html", "application/xhtml+html"],
     json: ["application/json", "application/vnd.api+json"],
     upload: ["multipart/form-data"],
+    rdf: ["text/turtle"],
     any: [ "*/*" ],
   ]
 
@@ -31,6 +32,13 @@ defmodule Dispatcher do
 
   match "/constraint-component/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://resource/constraint-component/"
+  end
+
+  ###############################################################
+  # validation
+  ###############################################################
+  post "/validate", %{ accept: [:rdf], layer: :api} do
+    Proxy.forward conn, [], "http://validation/validate"
   end
 end
 

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -36,9 +36,8 @@ services:
     volumes:
       - ./config:/config
     ports:
-      - 8090:8090
+      - 8090:80
     environment:
-      SERVER_PORT: "8090"
       DEFAULT_APPLICATION_PROFILE_PATH: "file:/config/applicationProfile.ttl"
       SPARQL_ENDPOINT: "http://db:8890" # todo change that
       MAX_REQUEST_SIZE: "512MB"

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     image: semtech/mu-dispatcher:latest
     links:
       - resource:resource
+      - validation:validation
     volumes:
       - ./config/dispatcher:/config
     labels:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: ${SERVER_PORT:8080}
+  port: ${SERVER_PORT:80}
 
 application-profile:
   default: ${DEFAULT_APPLICATION_PROFILE_PATH:classpath:default.shaclc}


### PR DESCRIPTION
This only passes through the POST to `/validate` since that's the only one that's needed on the frontend. The other API routes are still available through the :8090 port.